### PR TITLE
Move Lint CI job to a new workflow that runs on pull requests (and on merges)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,28 @@
+name: Lint
+on:
+  workflow_call:
+
+jobs:
+  Lint_and_Test:
+    name: Lint_and_Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 20 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,8 @@
+name: Lint PR
+
+on:
+  pull_request:
+
+jobs:
+  pr-lint:
+    uses: ./.github/workflows/lint.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,28 +6,7 @@ on:
 
 jobs:
   Lint_and_Test:
-    name: Lint_and_Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ 20 ]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@master
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Test
-        run: npm run test
+    uses: ./.github/workflows/lint.yaml
 
   Build_Release_and_Deploy:
     name: Build_Release_and_Deploy


### PR DESCRIPTION
This PR adds a "lint" CI job in a new workflow (`pr-lint.yaml`) to run linting on PRs. Linting is still also run on commits to `master` (as a prep step before release).

In order to use the exact same lint job configuration for both PRs and a pre-release check, I've created a new sub-workflow `lint.yaml` that contains the job steps for the linting itself.

I have otherwise not changed the content of the linting CI job, though I could look at possible improvements if this was desired (eg. annotating PR diffs with the linter failures).

Fixes https://github.com/eco-infra/ecoinfra/issues/20

## How Has This Been Tested?

Hard to test locally, but this PR will serve as a test of the PR-linting part.

I've verified the configuration using the excellent [actionlint](https://github.com/rhysd/actionlint) tool.